### PR TITLE
used auto keygen and fixed quote

### DIFF
--- a/sample-app/assets/js/main.js
+++ b/sample-app/assets/js/main.js
@@ -13,7 +13,7 @@ function onSimulation() {
       $('<div/>', {
         html: `<div class="row mt-3">
                 <div class="col s2">
-                  <p class="font-weight-bold">Public Key ${index + 1}</p>
+                  <p class="font-weight-bold">Generated Public Key ${index + 1}</p>
                 </div>
                 <div class="col s10">
                   <p>${item.publicKey}</p>
@@ -108,31 +108,24 @@ function onSimulation() {
     $('#vf_HashValidation').html(hashMatch);
 
     //Proactive Security
-    data.replaceKeyPairs.forEach((item, index) => {
-      $('<div/>', {
-        html: `<div class="row mt-3">
-                <div class="col s2">
-                  <p class="font-weight-bold">New Public Key ${index + 1}</p>
-                </div>
-                <div class="col s10">
-                  <p>${item.publicKey}</p>
-                </div>
-              </div>`,
-      }).appendTo('#newPublicKeys');
-    });
-
-    data.replacementEntryResponses.forEach((item, index) => {
-      $('<div/>', {
-        html: `<div class="row mt-3">
-                <div class="col s2">
-                  <p class="font-weight-bold">Entry Hash ${index + 1}</p>
-                </div>
-                <div class="col s10">
-                  <p>${item.entry_hash}</p>
-                </div>
-              </div>`,
-      }).appendTo('#replaceKeys');
-    });
+    $('<div/>', {
+      html: `<div class="row mt-3">
+              <div class="col s2">
+                <p class="font-weight-bold">Replacement Entry Hash</p>
+              </div>
+              <div class="col s10">
+                <p>${data.replacementEntryResponse.entry_hash}</p>
+              </div>
+            </div>
+            <div class="row mt-3">
+              <div class="col s2">
+                <p class="font-weight-bold">New Public Key</p>
+              </div>
+              <div class="col s10">
+                <p>${data.replaceKeyPair.publicKey}</p>
+              </div>
+            </div>`,
+    }).appendTo('#replaceKey');
 
     data.identityKeys.data.forEach((item, index) => {
       $('<div/>', {

--- a/sample-app/index.html
+++ b/sample-app/index.html
@@ -47,7 +47,7 @@
     <div id="result">
       <p>
         <a href="https://docs.harmony.factom.com/">Click here</a> to learn how
-        you to view the created data (chains and entries) using the Factom
+        to view the created data (chains and entries) using the Factom
         Explorer
       </p>
       <div class="section first-section">
@@ -55,10 +55,6 @@
           <h3>Initialization</h3>
         </div>
         <div class="section-body">
-          <h5 class="card-title">Generate Keys</h5>
-          <div id="generatePublicKeys">
-          </div>
-
           <h5 class="card-title">Create Identity (for notary company)</h5>
           <div class="row mt-3">
             <div class="col s2">
@@ -68,6 +64,7 @@
               <p id="identityChainId"></p>
             </div>
           </div>
+          <div id="generatePublicKeys">
         </div>
       </div>
 
@@ -125,7 +122,7 @@
             </div>
             <div class="row ml-10">
               <div class="col s2">
-                <p class="font-weight-bold">Signature</p>
+                <p class="font-weight-bold">Signature (hex)</p>
               </div>
               <div class="col s10">
                 <p id="chainSignature"></p>
@@ -215,7 +212,7 @@
               </div>
               <div class="row ml-10">
                 <div class="col s2">
-                  <p class="font-weight-bold">Signature</p>
+                  <p class="font-weight-bold">Signature (hex)</p>
                 </div>
                 <div class="col s10">
                   <p id="entrySignature"></p>
@@ -321,7 +318,7 @@
             </div>
             <div class="row ml-10">
               <div class="col s2">
-                <p class="font-weight-bold">Signature</p>
+                <p class="font-weight-bold">Signature (hex)</p>
               </div>
               <div class="col s10">
                 <p id="rc_chainSignature"></p>
@@ -425,7 +422,7 @@
             </div>
             <div class="row ml-10">
               <div class="col s2">
-                <p class="font-weight-bold">Signature</p>
+                <p class="font-weight-bold">Signature (hex)</p>
               </div>
               <div class="col s10">
                 <p id="rc_entrySignature"></p>
@@ -527,13 +524,8 @@
         </div>
         <div class="section-body">
           <div>
-            <h5 class="card-title">Generate New Keys</h5>
-            <div id="newPublicKeys">
-            </div>
-          </div>
-          <div>
-            <h5 class="card-title">Replace Keys</h5>
-            <div id="replaceKeys">
+            <h5 class="card-title">Replace Key</h5>
+            <div id="replaceKey">
             </div>
           </div>
           <div>

--- a/sample-app/simulateNotary.js
+++ b/sample-app/simulateNotary.js
@@ -35,7 +35,7 @@ module.exports = async (request, response) => {
       signerChainId: identityChainId,
       externalIds: ["NotarySimulation", "CustomerChain", "cust123"],
       content:
-        "This chain represents a notary service’s customer in the NotarySimulation, a sample implementation provided as part of the Factom Harmony SDKs. Learn more here: https://docs.harmony.factom.com/docs/sdks-clients"
+        "This chain represents a notary service's customer in the NotarySimulation, a sample implementation provided as part of the Factom Harmony SDKs. Learn more here: https://docs.harmony.factom.com/docs/sdks-clients"
     });
 
     /**
@@ -143,25 +143,15 @@ module.exports = async (request, response) => {
       hash: documentHashAfter,
       link: "/document",
     };
-    // Proactive Security
-    const replaceKeyPairs = [];
-    for(let i = 0; i < 3; i++) {
-      replaceKeyPairs.push(factomConnectSDK.utils.generateKeyPair());
-    }
 
-    //To replace new key, you need to sign this request with above or same level private key. In this case we are using same level private key.
-    const replacementEntryResponses = [];
-    for (let index = 0; index < replaceKeyPairs.length; index++) {
-      const newKeyPair = replaceKeyPairs[index];
-      const originalKeyPair = originalKeyPairs[index];
-      const replacementEntryResponse= await factomConnectSDK.identities.keys.replace({
-        identityChainId: identityChainId,
-        oldPublicKey: originalKeyPair.publicKey,
-        newPublicKey: newKeyPair.publicKey,
-        signerPrivateKey: originalKeyPair.privateKey,
-      })
-      replacementEntryResponses.push(replacementEntryResponse)
-    }
+    // Proactive Security
+    // To replace a key, you need to sign this request with the private key of the same level or above. In this case we are using one of the same level.
+    const originalKeyPair = originalKeyPairs[2];
+    const replacementEntryResponse = await factomConnectSDK.identities.keys.replace({
+      identityChainId: identityChainId,
+      oldPublicKey: originalKeyPair.publicKey,
+      signerPrivateKey: originalKeyPair.privateKey,
+    })
 
     const identityKeys = await factomConnectSDK.identities.keys.list({
       identityChainId: identityChainId,
@@ -196,8 +186,8 @@ module.exports = async (request, response) => {
         entryContentJSON: entryContentJSON,
       },
       documentAfter: documentAfter,
-      replaceKeyPairs: replaceKeyPairs,
-      replacementEntryResponses: replacementEntryResponses,
+      replaceKeyPair: replacementEntryResponse.key_pair,
+      replacementEntryResponse: replacementEntryResponse,
       identityKeys: identityKeys,
     });
   } catch (error) {


### PR DESCRIPTION
Implemented in this PR:
- switched to using autokey gen for the key replacement and updated output layout to reflect use of such (including on identity creation)
- only replaced one key instead of all (we only allow one key replacement per block so the change will now work in a simulation)
- minor text refinements of labels / typo fix
- fixed a quote that was non-UTF-8 and thus would not show in the Explorer as raw and instead would default to hex (see example [here](https://stage.explorer.factom.com/chains/3c70446f30d8bcf76c811a7bf8030d109a26a7ae09217323ec083c772df44fa2/entries/101585d1c20decf8e1b4894e6e84c044d1dbafdabc3b6eb2068fa5d0fa75c526))